### PR TITLE
New release 0.2.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.2.4] - 2023-07-10
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (3f7e252)
+
 ## [0.2.3] - 2023-07-10
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "netlink-packet-wireguard"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Leo <leo881003@gmail.com>", "Jake McGinty <me@jake.su>"]
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/rust-netlink/netlink-packet-wireguard"
 repository = "https://github.com/rust-netlink/netlink-packet-wireguard"
 keywords = ["wireguard", "netlink", "linux"]


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Use latest rust-netlink crates. (3f7e252)