### PR TITLE
New release 0.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,25 @@
 # Changelog
+## [0.3.0] - 2026-01-26
+### Breaking changes
+ - Rewrite to align with netlink-packet-route code style. (3067a39)
+     - All netlink attribute are marked as `#[non_exhaustive]`.
+     - Renamed `Wireguard` to `WireguardMessage`.
+     - Renamed `WgDeviceAttrs` to `WireguardAttribute`.
+     - Renamed `WgAllowedIp` to `WireguardAllowedIp`.
+     - Renamed `WgPeerAttrs` to `WireguardPeer`.
+     - Renamed `WgPeer` to `WireguardPeerAttribute`.
+     - Will not expose any constants.
+     - Changed the use of `std::time::SystemTime` to self-defined
+       `WireguardTimeSpec`.
+     - Do not raise error for unknown attribute but store in
+       `Self::Other(DefaultNla)`.
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A
+
 ## [0.2.4] - 2023-07-10
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlink-packet-wireguard"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Leo <leo881003@gmail.com>", "Jake McGinty <me@jake.su>"]
 edition = "2021"
 homepage = "https://github.com/rust-netlink/netlink-packet-wireguard"


### PR DESCRIPTION
=== Breaking changes
 - Rewrite to align with netlink-packet-route code style. (3067a39)
     - All netlink attribute are marked as `=[non_exhaustive]`.
     - Renamed `Wireguard` to `WireguardMessage`.
     - Renamed `WgDeviceAttrs` to `WireguardAttribute`.
     - Renamed `WgAllowedIp` to `WireguardAllowedIp`.
     - Renamed `WgPeerAttrs` to `WireguardPeer`.
     - Renamed `WgPeer` to `WireguardPeerAttribute`.
     - Will not expose any constants.
     - Changed the use of `std::time::SystemTime` to self-defined
       `WireguardTimeSpec`.
     - Do not raise error for unknown attribute but store in
       `Self::Other(DefaultNla)`.

=== New features
 - N/A

=== Bug fixes
 - N/A