### PR TITLE
API break: Add support of flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ libc = "0.2.98"
 log = "0.4.14"
 netlink-packet-generic = { version = "0.4.0" }
 netlink-packet-core = { version = "0.8.0" }
+bitflags = "2"
 
 [dev-dependencies]
 base64 = "0.13.0"

--- a/src/allowedip.rs
+++ b/src/allowedip.rs
@@ -2,14 +2,17 @@
 
 use std::net::IpAddr;
 
+use bitflags::bitflags;
 use netlink_packet_core::{
-    emit_u16, parse_ip, parse_u16, DecodeError, DefaultNla, Emitable,
-    ErrorContext, Nla, NlaBuffer, NlasIterator, Parseable, NLA_F_NESTED,
+    emit_u16, emit_u32, parse_ip, parse_u16, parse_u32, DecodeError,
+    DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, NlasIterator,
+    Parseable, NLA_F_NESTED,
 };
 
 const WGALLOWEDIP_A_FAMILY: u16 = 1;
 const WGALLOWEDIP_A_IPADDR: u16 = 2;
 const WGALLOWEDIP_A_CIDR_MASK: u16 = 3;
+const WGALLOWEDIP_A_FLAGS: u16 = 4;
 
 pub(crate) struct WireguardAllowedIps(pub(crate) Vec<WireguardAllowedIp>);
 
@@ -106,12 +109,26 @@ impl From<WireguardAddressFamily> for u16 {
     }
 }
 
+const WGALLOWEDIP_F_REMOVE_ME: u32 = 1;
+
+// TODO: Once wireguard-tools support this flag, add unit test for using
+//       captured netlink packet.
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub struct WireguardAllowedIpFlags: u32 {
+        const RemoveMe = WGALLOWEDIP_F_REMOVE_ME;
+        const _ = !0;
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum WireguardAllowedIpAttr {
     Family(WireguardAddressFamily),
     IpAddr(IpAddr),
     Cidr(u8),
+    Flags(WireguardAllowedIpFlags),
     Other(DefaultNla),
 }
 
@@ -124,6 +141,7 @@ impl Nla for WireguardAllowedIpAttr {
                 IpAddr::V6(_) => 16,
             },
             Self::Cidr(_) => 1,
+            Self::Flags(_) => 4,
             Self::Other(nla) => nla.value_len(),
         }
     }
@@ -133,6 +151,7 @@ impl Nla for WireguardAllowedIpAttr {
             Self::Family(_) => WGALLOWEDIP_A_FAMILY,
             Self::IpAddr(_) => WGALLOWEDIP_A_IPADDR,
             Self::Cidr(_) => WGALLOWEDIP_A_CIDR_MASK,
+            Self::Flags(_) => WGALLOWEDIP_A_FLAGS,
             Self::Other(nla) => nla.kind(),
         }
     }
@@ -145,6 +164,7 @@ impl Nla for WireguardAllowedIpAttr {
                 IpAddr::V6(ip) => buffer.copy_from_slice(&ip.octets()),
             },
             Self::Cidr(v) => buffer[0] = *v,
+            Self::Flags(v) => emit_u32(buffer, v.bits()).unwrap(),
             Self::Other(nla) => nla.emit_value(buffer),
         }
     }
@@ -166,6 +186,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     .context("invalid WGALLOWEDIP_A_IPADDR value")?,
             ),
             WGALLOWEDIP_A_CIDR_MASK => Self::Cidr(payload[0]),
+            WGALLOWEDIP_A_FLAGS => {
+                Self::Flags(WireguardAllowedIpFlags::from_bits_retain(
+                    parse_u32(payload)
+                        .context("invalid WGALLOWEDIP_A_FLAGS value")?,
+                ))
+            }
             kind => Self::Other(
                 DefaultNla::parse(buf)
                     .context(format!("unknown NLA type {kind}"))?,

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -2,6 +2,7 @@
 
 use std::convert::TryInto;
 
+use bitflags::bitflags;
 use netlink_packet_core::{
     emit_u16, emit_u32, parse_string, parse_u16, parse_u32, DecodeError,
     DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer, Parseable,
@@ -22,6 +23,17 @@ const WGDEVICE_A_LISTEN_PORT: u16 = 6;
 const WGDEVICE_A_FWMARK: u16 = 7;
 const WGDEVICE_A_PEERS: u16 = 8;
 
+const WGDEVICE_F_REPLACE_PEERS: u32 = 1;
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub struct WireguardDeviceFlags: u32 {
+        const ReplacePeers = WGDEVICE_F_REPLACE_PEERS;
+        const _ = !0;
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum WireguardAttribute {
@@ -32,7 +44,7 @@ pub enum WireguardAttribute {
     ListenPort(u16),
     Fwmark(u32),
     Peers(Vec<WireguardPeer>),
-    Flags(u32),
+    Flags(WireguardDeviceFlags),
     Other(DefaultNla),
 }
 
@@ -78,7 +90,7 @@ impl Nla for WireguardAttribute {
             Self::ListenPort(v) => emit_u16(buffer, *v).unwrap(),
             Self::Fwmark(v) => emit_u32(buffer, *v).unwrap(),
             Self::Peers(v) => v.as_slice().emit(buffer),
-            Self::Flags(v) => emit_u32(buffer, *v).unwrap(),
+            Self::Flags(v) => emit_u32(buffer, v.bits()).unwrap(),
             Self::Other(attr) => attr.emit_value(buffer),
         }
     }
@@ -123,9 +135,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                     .context("invalid WGDEVICE_A_FWMARK value")?,
             ),
             WGDEVICE_A_PEERS => Self::Peers(WireguardPeers::parse(buf)?.0),
-            WGDEVICE_A_FLAGS => Self::Flags(
-                parse_u32(payload).context("invalid WGDEVICE_A_FLAGS value")?,
-            ),
+            WGDEVICE_A_FLAGS => {
+                Self::Flags(WireguardDeviceFlags::from_bits_retain(
+                    parse_u32(payload)
+                        .context("invalid WGDEVICE_A_FLAGS value")?,
+                ))
+            }
             kind => Self::Other(
                 DefaultNla::parse(buf)
                     .context(format!("unknown NLA type {kind}"))?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,12 @@ mod test;
 pub use self::{
     allowedip::{
         WireguardAddressFamily, WireguardAllowedIp, WireguardAllowedIpAttr,
+        WireguardAllowedIpFlags,
     },
-    attribute::WireguardAttribute,
+    attribute::{WireguardAttribute, WireguardDeviceFlags},
     message::{WireguardCmd, WireguardMessage},
-    peer::{WireguardPeer, WireguardPeerAttribute, WireguardTimeSpec},
+    peer::{
+        WireguardPeer, WireguardPeerAttribute, WireguardPeerFlags,
+        WireguardTimeSpec,
+    },
 };

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -2,6 +2,7 @@
 
 use std::{convert::TryInto, net::SocketAddr};
 
+use bitflags::bitflags;
 use netlink_packet_core::{
     emit_i64, emit_u16, emit_u32, emit_u64, parse_i64, parse_u16, parse_u32,
     parse_u64, DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
@@ -135,6 +136,21 @@ const WGPEER_A_TX_BYTES: u16 = 8;
 const WGPEER_A_ALLOWEDIPS: u16 = 9;
 const WGPEER_A_PROTOCOL_VERSION: u16 = 10;
 
+const WGPEER_F_REMOVE_ME: u32 = 1;
+const WGPEER_F_REPLACE_ALLOWEDIPS: u32 = 2;
+const WGPEER_F_UPDATE_ONLY: u32 = 4;
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub struct WireguardPeerFlags: u32 {
+        const RemoveMe = WGPEER_F_REMOVE_ME;
+        const ReplaceAllowedIps = WGPEER_F_REPLACE_ALLOWEDIPS;
+        const UpdateOnly = WGPEER_F_UPDATE_ONLY;
+        const _ = !0;
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum WireguardPeerAttribute {
@@ -147,7 +163,7 @@ pub enum WireguardPeerAttribute {
     TxBytes(u64),
     AllowedIps(Vec<WireguardAllowedIp>),
     ProtocolVersion(u32),
-    Flags(u32),
+    Flags(WireguardPeerFlags),
     Other(DefaultNla),
 }
 
@@ -166,7 +182,7 @@ impl Nla for WireguardPeerAttribute {
             Self::TxBytes(v) => size_of_val(v),
             Self::AllowedIps(v) => v.as_slice().buffer_len(),
             Self::ProtocolVersion(v) => size_of_val(v),
-            Self::Flags(v) => size_of_val(v),
+            Self::Flags(_) => 4,
             Self::Other(v) => v.value_len(),
         }
     }
@@ -200,7 +216,7 @@ impl Nla for WireguardPeerAttribute {
             Self::TxBytes(v) => emit_u64(buffer, *v).unwrap(),
             Self::AllowedIps(v) => v.as_slice().emit(buffer),
             Self::ProtocolVersion(v) => emit_u32(buffer, *v).unwrap(),
-            Self::Flags(v) => emit_u32(buffer, *v).unwrap(),
+            Self::Flags(v) => emit_u32(buffer, v.bits()).unwrap(),
             Self::Other(v) => v.emit_value(buffer),
         }
     }
@@ -256,9 +272,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
                 parse_u32(payload)
                     .context("invalid WGPEER_A_PROTOCOL_VERSION value")?,
             ),
-            WGPEER_A_FLAGS => Self::Flags(
-                parse_u32(payload).context("invalid WGPEER_A_FLAGS value")?,
-            ),
+            WGPEER_A_FLAGS => {
+                Self::Flags(WireguardPeerFlags::from_bits_retain(
+                    parse_u32(payload)
+                        .context("invalid WGPEER_A_FLAGS value")?,
+                ))
+            }
             kind => Self::Other(
                 DefaultNla::parse(buf)
                     .context(format!("unknown NLA type {kind}"))?,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use std::{
-    net::{IpAddr, Ipv4Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str::FromStr,
 };
 
@@ -11,8 +11,9 @@ use pretty_assertions::assert_eq;
 
 use crate::{
     WireguardAddressFamily, WireguardAllowedIp, WireguardAllowedIpAttr,
-    WireguardAttribute, WireguardCmd, WireguardMessage, WireguardPeer,
-    WireguardPeerAttribute, WireguardTimeSpec,
+    WireguardAttribute, WireguardCmd, WireguardDeviceFlags, WireguardMessage,
+    WireguardPeer, WireguardPeerAttribute, WireguardPeerFlags,
+    WireguardTimeSpec,
 };
 
 // nlmon capture of netlink packet sent by `sudo wg` command with netlink
@@ -123,6 +124,88 @@ fn test_query_reply() {
                         )),
                     ],
                 )]),
+            ])]),
+        ],
+    };
+
+    let header = GenlHeader::parse(&GenlBuffer::new(&raw)).unwrap();
+
+    assert_eq!(
+        expected,
+        WireguardMessage::parse_with_param(&raw[4..], header).unwrap(),
+    );
+
+    let mut buffer = vec![0; expected.buffer_len() + header.buffer_len()];
+    header.emit(&mut buffer);
+    expected.emit(&mut buffer[4..]);
+    assert_eq!(&buffer, &raw);
+}
+
+// nlmon capture of kernel netlink packet reply of `sudo wg setconf` command
+// against existing wireguard interface
+#[test]
+fn test_setconf_against_exiting_wg() {
+    let raw: Vec<u8> = vec![
+        0x01, 0x01, 0x00, 0x00, 0x08, 0x00, 0x02, 0x00, 0x77, 0x67, 0x30, 0x00,
+        0x24, 0x00, 0x03, 0x00, 0x08, 0xf8, 0x74, 0x0f, 0xc2, 0x87, 0xda, 0x7a,
+        0x1c, 0x44, 0xfc, 0x1a, 0x73, 0x5c, 0xec, 0xf3, 0xb0, 0x9e, 0x33, 0x81,
+        0x18, 0x22, 0x08, 0x75, 0x34, 0x8b, 0x88, 0xac, 0x75, 0x5b, 0xfe, 0x59,
+        0x06, 0x00, 0x06, 0x00, 0x03, 0xd9, 0x00, 0x00, 0x08, 0x00, 0x07, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x7c, 0x00, 0x08, 0x80, 0x78, 0x00, 0x00, 0x80, 0x24, 0x00, 0x01, 0x00,
+        0x7b, 0xff, 0x32, 0x8c, 0x65, 0x6b, 0x0d, 0xa2, 0x38, 0x58, 0x16, 0xee,
+        0x0b, 0x47, 0xe9, 0xdc, 0x5b, 0xba, 0x3b, 0xf7, 0x79, 0x82, 0xd8, 0xdc,
+        0x99, 0x34, 0x73, 0xed, 0xe5, 0x72, 0xb4, 0x0f, 0x08, 0x00, 0x03, 0x00,
+        0x02, 0x00, 0x00, 0x00, 0x48, 0x00, 0x09, 0x80, 0x1c, 0x00, 0x00, 0x80,
+        0x06, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x08, 0x00, 0x02, 0x00,
+        0xc0, 0x00, 0x02, 0x02, 0x05, 0x00, 0x03, 0x00, 0x20, 0x00, 0x00, 0x00,
+        0x28, 0x00, 0x00, 0x80, 0x06, 0x00, 0x01, 0x00, 0x0a, 0x00, 0x00, 0x00,
+        0x14, 0x00, 0x02, 0x00, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x01, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x05, 0x00, 0x03, 0x00,
+        0x80, 0x00, 0x00, 0x00,
+    ];
+
+    let expected = WireguardMessage {
+        cmd: WireguardCmd::SetDevice,
+        attributes: vec![
+            WireguardAttribute::IfName("wg0".to_string()),
+            WireguardAttribute::PrivateKey([
+                8, 248, 116, 15, 194, 135, 218, 122, 28, 68, 252, 26, 115, 92,
+                236, 243, 176, 158, 51, 129, 24, 34, 8, 117, 52, 139, 136, 172,
+                117, 91, 254, 89,
+            ]),
+            WireguardAttribute::ListenPort(55555),
+            WireguardAttribute::Fwmark(0),
+            WireguardAttribute::Flags(WireguardDeviceFlags::ReplacePeers),
+            WireguardAttribute::Peers(vec![WireguardPeer(vec![
+                WireguardPeerAttribute::PublicKey([
+                    123, 255, 50, 140, 101, 107, 13, 162, 56, 88, 22, 238, 11,
+                    71, 233, 220, 91, 186, 59, 247, 121, 130, 216, 220, 153,
+                    52, 115, 237, 229, 114, 180, 15,
+                ]),
+                WireguardPeerAttribute::Flags(
+                    WireguardPeerFlags::ReplaceAllowedIps,
+                ),
+                WireguardPeerAttribute::AllowedIps(vec![
+                    WireguardAllowedIp(vec![
+                        WireguardAllowedIpAttr::Family(
+                            WireguardAddressFamily::Ipv4,
+                        ),
+                        WireguardAllowedIpAttr::IpAddr(IpAddr::V4(
+                            Ipv4Addr::new(192, 0, 2, 2),
+                        )),
+                        WireguardAllowedIpAttr::Cidr(32),
+                    ]),
+                    WireguardAllowedIp(vec![
+                        WireguardAllowedIpAttr::Family(
+                            WireguardAddressFamily::Ipv6,
+                        ),
+                        WireguardAllowedIpAttr::IpAddr(IpAddr::V6(
+                            Ipv6Addr::from_str("2001:db8:1::2").unwrap(),
+                        )),
+                        WireguardAllowedIpAttr::Cidr(128),
+                    ]),
+                ]),
             ])]),
         ],
     };


### PR DESCRIPTION
Included support of these flags:
 * `WireguardDeviceFlags`
 * `WireguardPeerAttribute`
 * `WireguardAllowedIpFlags`

Unit test cases included except `WireguardAllowedIpFlags` which is not
supported by wireguard-tools yet and kernel query does not set that NLA
neither.