### PR TITLE
New release 0.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 # Changelog
+## [0.4.0] - 2026-05-13
+### Breaking changes
+ - Changed `WireguardAttribute::Flags` from u32 to enum. (f860bde)
+ - Changed `WireguardAllowedIpAttr::Flags` from u32 to enum. (f860bde)
+ - Changed `WireguardPeerAttribute::Flags` from u32 to enum. (f860bde)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A
+
 ## [0.3.1] - 2026-05-08
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlink-packet-wireguard"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Leo <leo881003@gmail.com>", "Jake McGinty <me@jake.su>"]
 edition = "2021"
 homepage = "https://github.com/rust-netlink/netlink-packet-wireguard"


### PR DESCRIPTION
=== Breaking changes
 - Changed `WireguardAttribute::Flags` from u32 to enum. (f860bde)
 - Changed `WireguardAllowedIpAttr::Flags` from u32 to enum. (f860bde)
 - Changed `WireguardPeerAttribute::Flags` from u32 to enum. (f860bde)

=== New features
 - N/A

=== Bug fixes
 - N/A