### PR TITLE
Update several dev-dependencies across SemVer boundaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ getrandom = "0.2.10"
 netlink-proto = { version = "0.12" }
 genetlink = { version = "0.2.6" }
 tokio = { version = "1.9.0", features = ["macros", "rt-multi-thread"] }
-pretty_assertions = "0.7.2"
+pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ netlink-packet-core = { version = "0.8.0" }
 bitflags = "2"
 
 [dev-dependencies]
-base64 = "0.13.0"
+base64 = "0.22.1"
 env_logger = "0.11.10"
 futures = "0.3.16"
 getrandom = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "2"
 
 [dev-dependencies]
 base64 = "0.13.0"
-env_logger = "0.10.0"
+env_logger = "0.11.10"
 futures = "0.3.16"
 getrandom = "0.2.10"
 netlink-proto = { version = "0.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bitflags = "2"
 base64 = "0.13.0"
 env_logger = "0.11.10"
 futures = "0.3.16"
-getrandom = "0.2.10"
+getrandom = "0.4.2"
 netlink-proto = { version = "0.12" }
 genetlink = { version = "0.2.6" }
 tokio = { version = "1.9.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/get_wireguard_info.rs
+++ b/examples/get_wireguard_info.rs
@@ -2,6 +2,7 @@
 
 use std::env::args;
 
+use base64::Engine;
 use futures::StreamExt;
 use genetlink::new_connection;
 use netlink_packet_core::{
@@ -59,7 +60,10 @@ fn print_wg_payload(wg: WireguardMessage) {
                 println!("PrivateKey: (hidden)")
             }
             WireguardAttribute::PublicKey(v) => {
-                println!("PublicKey: {}", base64::encode(v))
+                println!(
+                    "PublicKey: {}",
+                    base64::engine::general_purpose::STANDARD.encode(v)
+                )
             }
             WireguardAttribute::ListenPort(v) => println!("ListenPort: {}", v),
             WireguardAttribute::Fwmark(v) => println!("Fwmark: {}", v),
@@ -78,7 +82,10 @@ fn print_wg_peer(attrs: &[WireguardPeerAttribute]) {
     for attr in attrs {
         match attr {
             WireguardPeerAttribute::PublicKey(v) => {
-                println!("  PublicKey: {}", base64::encode(v))
+                println!(
+                    "  PublicKey: {}",
+                    base64::engine::general_purpose::STANDARD.encode(v)
+                )
             }
             WireguardPeerAttribute::PresharedKey(_) => {
                 println!("  PresharedKey: (hidden)")

--- a/examples/set_wireguard.rs
+++ b/examples/set_wireguard.rs
@@ -6,6 +6,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 
+use base64::Engine;
 use futures::StreamExt;
 use genetlink::new_connection;
 use netlink_packet_core::{
@@ -33,7 +34,8 @@ async fn main() {
     let name = argv[1].clone();
     let priv_key = generate_priv_key();
     let peer_pub_key: [u8; WireguardAttribute::WG_KEY_LEN] =
-        base64::decode("8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk=")
+        base64::engine::general_purpose::STANDARD
+            .decode("8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk=")
             .unwrap()
             .try_into()
             .unwrap();

--- a/examples/set_wireguard.rs
+++ b/examples/set_wireguard.rs
@@ -93,7 +93,7 @@ async fn main() {
 
 fn generate_priv_key() -> [u8; WireguardAttribute::WG_KEY_LEN] {
     let mut key = [0u8; WireguardAttribute::WG_KEY_LEN];
-    getrandom::getrandom(&mut key).unwrap();
+    getrandom::fill(&mut key).unwrap();
     // modify random bytes using algorithm described
     // at https://cr.yp.to/ecdh.html.
     key[0] &= 248;


### PR DESCRIPTION
Update `pretty_assertions`, `env_logger`, `getrandom`, and `base64` dev-dependencies across SemVer boundaries to their latest versions. The latter two required minor source-code changes.